### PR TITLE
Fix undefined in history

### DIFF
--- a/app/electron/index.js
+++ b/app/electron/index.js
@@ -46,8 +46,12 @@ function newWin () {
     webPreferences: {
       nodeIntegration: false
     },
-    width: 1200,
-    height: 800,
+    width: userConfig.bounds.width 
+      ? userConfig.bounds.width 
+      : 1200,
+    height: userConfig.bounds.height 
+      ? userConfig.bounds.height 
+      : 800,
     titleBarStyle: 'hidden',
     frame: process.platform === 'darwin',
     show: false
@@ -55,6 +59,20 @@ function newWin () {
 
   win.once('ready-to-show', () => {
     win.show()
+  })
+
+  win.on('close', () => {
+    const bounds = win.getBounds()
+    const config = join(systemFolder, 'config.json')
+    fs.readFile(config, 'utf-8', (error, data) => {
+      if (error) {
+        // failed to read file
+      } else {
+        const json = JSON.parse(data)
+        json.config.bounds = bounds
+        fs.writeFileSync(config, JSON.stringify(json), 'utf-8')
+      }
+    })
   })
 
   win.on('closed', () => {

--- a/app/web/components/historyModal.vue
+++ b/app/web/components/historyModal.vue
@@ -107,7 +107,7 @@ export default {
       this.elems = {}
 
       for (let i = 0, l = this.nbElems; i < l; ++i) {
-        this.elems[keys[i]] = this.history[keys[i]]
+        if (this.history[keys[i]] !== undefined) this.elems[keys[i]] = this.history[keys[i]]
       }
     }
   },


### PR DESCRIPTION
The history modal adds an 'undefined' to the bottom, as you can see here:
![screenshot_2018-09-03_17-15-39](https://user-images.githubusercontent.com/39978992/45002177-fc29e680-afa1-11e8-814f-84feee7d6828.png)

This should get rid of it.